### PR TITLE
Swift、Xcode用のgitignoreを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,83 @@
+# Custom swift & Xcode gitignore
+# Cache & build files
+DerivedData/
+/.build
+build/
+
+# Generated file
+R.generated.swift
+
+# Firebase analytics config file
+GoogleService-Info.plist
+
+
+
+# ref: https://github.com/github/gitignore/blob/main/Swift.gitignore
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+
+
 # ref: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General
 .DS_Store


### PR DESCRIPTION
📚 Description
- [x] Swift、Xcode用のgitignoreを作成
- カスタム設定では、キャッシュファイルやビルド情報ファイルを含めました。
- カスタム設定では、今後使用する予定の分(R.generated.swift、GoogleService-Info.plist)も含めました。
- github.com/github/gitignoreリポジトリからSwift.gitignore、macOS.gitignoreをコピペしました。